### PR TITLE
Fix Spin-Up configuration

### DIFF
--- a/Adafruit_EMC2101.cpp
+++ b/Adafruit_EMC2101.cpp
@@ -188,7 +188,7 @@ bool Adafruit_EMC2101::configFanSpinup(uint8_t spinup_drive,
 
   Adafruit_BusIO_RegisterBits _spin_time_bits =
       Adafruit_BusIO_RegisterBits(&spin_config, 3, 0);
-  if (!_spin_drive_bits.write(spinup_time)) {
+  if (!_spin_time_bits.write(spinup_time)) {
     return false;
   }
 }


### PR DESCRIPTION
Bits which configured the spin-up time (bits 0 through 2) were
accidentally being written to the spin-up duty cycle bits (bits 3 and
4), causing unexpected behavior.

Spin-up time was persistently stuck on the default (3.2 seconds), and
the duty cycle (default, 100%) was actually being overwritten by the
commanded time bits.