### PR TITLE
Minor fix and misc clean up

### DIFF
--- a/Adafruit_EMC2101.h
+++ b/Adafruit_EMC2101.h
@@ -66,8 +66,6 @@
   5400000               ///< Conversion unit to convert LSBs to fan RPM
 #define _TEMP_LSB 0.125 ///< single bit value for internal temperature readings
 
-#define MAX_LUT_SPEED 0x3F ///< 6-bit value
-#define MAX_LUT_TEMP 0x7F  ///< 7-bit
 
 /**
  * @brief

--- a/Adafruit_EMC2101.h
+++ b/Adafruit_EMC2101.h
@@ -66,7 +66,6 @@
   5400000               ///< Conversion unit to convert LSBs to fan RPM
 #define _TEMP_LSB 0.125 ///< single bit value for internal temperature readings
 
-
 /**
  * @brief
  *


### PR DESCRIPTION
For #4. Tested with Itsy M0 using examples from library. Everything compiles and runs as expected.

Summary of changes made / not made:

> Adafruit_EMC2101.h
> Line 69 : Duplicate of line 61
> Line 70 : Duplicate of line 62

Deleted dupes.

> Adafruit_EMC2101.cpp
> Line 162 : States clkovr_bit.write(clksel)
> Should be clkovr_bit.write(clkovr)

Yep, looks like a typo. Fixed. Thanks. **This appears to be the only actual bug.**

> 
> Lines 416-420: This is not an error but the code could be made more consistent
> Line 416 states lsb_value = EMC2101_FAN_RPM_NUMERATOR / min_rpm
> At tis point, you're not calculatign the lsb.
> This is actually a raw limit value that includes the msb and lsb.
> In the getFanMinRPM function, you call this value "raw_limit"
> For consistency, you could change:
> Line 416 to: uint16_t raw_limit = EMC2101_FAN_RPM_NUMERATOR / min_rpm;
> Line 417 to: if (!tach_limit_lsb.write(raw_limit & 0xFF)) {
> line 420 to: if (!tach_limit_msb.write((raw_limit >> 8) & 0xFF)) {

Cosmetic, but OK. Changed.

> Lines 445-449: When reading the external temperature, I think you are
> ignoring the sign bit. This means that a negative temperature will
> read like a very high temperature.

Implicit cast to `int16_t` will take care of this. No change.

> Line 449: You have a variable for the _TEMP_LSB, suggestion to use that
> instead of typing the number out again

Agree. Changed.

> Lines 459-462: Not an error but a variable name inconsistency.
> You are using the variable ext_temp_lsb when we are reading
> the internal temp, not the external temp.

Another cosmetic change. Done.

> Lines 457-462: Again, you are ignoring the sign bit.

Implicit cast again (see above). No change.

> Line 489: You have a variable for the EMC2101_FAN_RPM_NUMERATOR, suggestion
> to use that instead of typing the number out again.

Agree. Changed.

> Lines 637-656: In get and set forced temperature functions you are ignoring
> the sign bit again (as above)

Implicit cast again. (see above) No change.

Simple example to demonstrate implicit cast works.
```cpp
#include <Adafruit_EMC2101.h>

Adafruit_EMC2101  emc2101;

void setup() {
  Serial.begin(9600);
  while (!Serial);
  Serial.println("Adafruit EMC2101 test!");

  if (!emc2101.begin()) {
    Serial.println("Failed to find EMC2101 chip");
    while (1) { delay(10); }
  }
  Serial.println("EMC2101 Found!");
 
  emc2101.setForcedTemperature(-25);
  Serial.print("Forced temperature = ");
  Serial.println(emc2101.getForcedTemperature());
}

void loop() {
}
```
![Screenshot from 2022-06-06 11-58-51](https://user-images.githubusercontent.com/8755041/172228622-b832a63b-030f-4c0b-b568-a8c0259a7061.png)





